### PR TITLE
Added changes to track all patrons

### DIFF
--- a/lib/park.rb
+++ b/lib/park.rb
@@ -29,4 +29,22 @@ class Park
             end
         end
     end 
+
+    def all_attendess
+        list_all_passengers.sort_by do |attendee| 
+            attendee.name 
+        end
+    end
+
+    def all_adults
+        all_attendess.find_all do |attendee|
+            attendee.adult?
+        end
+    end
+
+    def all_minors
+        all_attendess.find_all do |attendee|
+            !attendee.adult?
+        end
+    end
 end

--- a/spec/park_spec.rb
+++ b/spec/park_spec.rb
@@ -48,10 +48,51 @@ RSpec.describe Park do
             @vehicle_1.add_passenger(@charlie)
             @vehicle_1.add_passenger(@jake)
             @vehicle_1.add_passenger(@taylor) 
-
+            
             @park.enter_park(@vehicle_1) 
-
+            
             expect(@park.revenue).to eq 20
         end 
     end
+    
+    describe 'tracking all patrons' do 
+        it 'can alphabetically list #all_attendess' do 
+            @vehicle_1.add_passenger(@charlie)
+            @vehicle_1.add_passenger(@jake)
+            @vehicle_1.add_passenger(@taylor) 
+            @vehicle_2.add_passenger(@devin)
+            @vehicle_2.add_passenger(@teddy)
+            @vehicle_2.add_passenger(@jude) 
+            @park.enter_park(@vehicle_1) 
+            @park.enter_park(@vehicle_2) 
+
+            expect(@park.all_attendess).to eq [@charlie, @devin, @jake, @jude, @taylor, @teddy]
+        end
+
+        it 'can alphabetically list #all_adults' do 
+            @vehicle_1.add_passenger(@charlie)
+            @vehicle_1.add_passenger(@jake)
+            @vehicle_1.add_passenger(@taylor) 
+            @vehicle_2.add_passenger(@devin)
+            @vehicle_2.add_passenger(@teddy)
+            @vehicle_2.add_passenger(@jude) 
+            @park.enter_park(@vehicle_1) 
+            @park.enter_park(@vehicle_2) 
+
+            expect(@park.all_adults).to eq [@charlie, @devin, @jake]
+        end
+        
+        it 'can alphabetically list #all_minors' do 
+            @vehicle_1.add_passenger(@charlie)
+            @vehicle_1.add_passenger(@jake)
+            @vehicle_1.add_passenger(@taylor) 
+            @vehicle_2.add_passenger(@devin)
+            @vehicle_2.add_passenger(@teddy)
+            @vehicle_2.add_passenger(@jude) 
+            @park.enter_park(@vehicle_1) 
+            @park.enter_park(@vehicle_2) 
+        
+            expect(@park.all_minors).to eq [@jude, @taylor, @teddy]
+        end
+    end 
 end 


### PR DESCRIPTION
Track all patrons

Added functionality and tests for:

- Alphabetically list all park attendees (#all_attendees)
- Alphabetically list all park attendees that are adults (#all_adults)
- Alphabetically list all park attendees that are minors (#all_minors)